### PR TITLE
Fix pgrep (and process killing) on older Linuxes

### DIFF
--- a/R/get_pid.R
+++ b/R/get_pid.R
@@ -16,6 +16,7 @@ get_children_windows <- function(pid) {
 
 get_children_unix <- function(pid) {
   res <- pgrep(c("-P", pid))
+  print(res)
   pid <- scan(text = res$stdout, what = 1, quiet = TRUE)
   pid
 }

--- a/R/get_pid.R
+++ b/R/get_pid.R
@@ -15,8 +15,7 @@ get_children_windows <- function(pid) {
 }
 
 get_children_unix <- function(pid) {
-  res <- pgrep(c("-P", pid))
-  print(res)
+  res <- pgrep_children(pid)
   pid <- scan(text = res$stdout, what = 1, quiet = TRUE)
   pid
 }

--- a/R/pgrep.R
+++ b/R/pgrep.R
@@ -13,6 +13,7 @@ pgrep <- function(args) {
 }
 
 pgrep_linux <- function(args) {
+  print(safe_system("pgrep", "--version"))
   out <- safe_system("pgrep", c("-a", args))
 
   if (out$status > 0) {

--- a/R/pgrep.R
+++ b/R/pgrep.R
@@ -3,40 +3,28 @@
 ## (e.g. Linux) it does include its ancestors, which is a problem for us
 ## Here we make sure that ancestors are excluded on Linux
 
-pgrep <- function(args) {
+pgrep_children <- function(pid) {
   if (is_linux()) {
-    pgrep_linux(args)
+    pgrep_children_linux(pid)
 
   } else {
-    pgrep_unix(args)
+    pgrep_children_unix(pid)
   }
 }
 
-pgrep_linux <- function(args) {
-  print(safe_system("pgrep", "--version"))
-  out <- safe_system("pgrep", c("-a", args))
+## Some old Linux systems do not support pgrep -a, so we cannot filter the
+## processes based on their command line. We get all child processes
+## including pgrep's ancestors, and then use ps to list them again.
+## This effectively filters out pgrep and its ancestors.
 
-  if (out$status > 0) {
-    ## Some error, or no processes found, do not touch
-    out
-
-  } else {
-    out$stdout <- strsplit(out$stdout, "\n", fixed = TRUE)[[1]]
-    out$stdout <- grep(
-      "^[0-9]+ sh -c 'pgrep'",
-      out$stdout,
-      value = TRUE,
-      invert = TRUE
-    )
-    out$stdout <- sub("^([0-9]+).*$", "\\1", out$stdout, perl = TRUE)
-    out$stdout <- paste(out$stdout, collapse = "\n")
-
-    ## status denotes if there was a match
-    if (out$stdout == "") out$status <- 1
-    out
-  }
+pgrep_children_linux <- function(pid) {
+  allproc <- safe_system("pgrep", c("-d,", pid))
+  safe_system(
+    "ps",
+    c("-o", "pid", "--no-header", "-p", str_trim(allproc$stdout))
+  )
 }
 
-pgrep_unix <- function(args) {
-  safe_system("pgrep", args)
+pgrep_children_unix <- function(pid) {
+  safe_system("pgrep", c("-P", pid))
 }


### PR DESCRIPTION
By using a more robust way to call pgrep.